### PR TITLE
do not ignore /vendor/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/vendor/
 /.idea/
 .*.sw[op]


### PR DESCRIPTION
The v0.3.0 .gitignore says GitClients to ignore the important directory /vendor/ removing it from .gitignore